### PR TITLE
Fix swallowed error

### DIFF
--- a/lib/Template.js
+++ b/lib/Template.js
@@ -25,10 +25,8 @@ Template.prototype = {
     return this.api.request(endpoint, 'POST', data)
       .then(function(result) {
         return result.content;
-      }).
-      catch(function(err) {
-        Promise.reject(err);
-      });
+      })
+      .catch(Promise.reject.bind(Promise));
   }
 
 };


### PR DESCRIPTION
Need to either return the call to Promise.reject passing in err explicitly or pass in just the function Promise.reject as a first class citizen.
