### PR TITLE
Updates SDK in preparation for the v1.1 update to the Wordsmith API.

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Returns a the data schema of a specific Project. The data schema details the dat
 ```javascript
 wordsmith.projects.find('YOUR_PROJECT_SLUG')
   .then(function(project) {
-    return project.schema();
+    return project.schema;
   })
   .then(function(schema) {
     // do something with schema
@@ -115,7 +115,7 @@ wordsmith.projects.find('YOUR_PROJECT_SLUG')
 
 ### Generate Content
 
-Turns data into narrative content. Data should be in the form of an object with keys for each data variable your Template uses. To see which keys are required, look at the data schema returned by `project.schema()` above.
+Turns data into narrative content. Data should be in the form of an object with keys for each data variable your Template uses. To see which keys are required, look at the data schema returned by `project.schema` above.
 
 ```javascript
 wordsmith.projects.find('YOUR_PROJECT_SLUG')

--- a/lib/Project.js
+++ b/lib/Project.js
@@ -6,17 +6,8 @@ function Project(project, apiClient) {
   this.api = apiClient;
   this.slug = project.slug;
   this.name = project.name;
+  this.schema = project.schema;
   this.templates = new TemplateCollection(project, apiClient);
 }
-
-Project.prototype = {
-
-  schema: function() {
-    return this.api.request('projects/' + this.slug, 'get').then(function(response) {
-      return response.schema;
-    });
-  }
-
-};
 
 module.exports = Project;

--- a/test/Project.spec.js
+++ b/test/Project.spec.js
@@ -22,21 +22,12 @@ describe('Project', function () {
     it('should create a project object', function() {
       var p =  new Project(testProject, apiClient);
       expect( p ).to.be.a('object');
-      expect( p ).to.respondTo('schema');
       expect( p ).to.have.property('templates');
       expect( p ).to.have.property('name');
       expect( p ).to.have.property('slug');
       expect( p ).to.have.property('api');
-    });
-
-  });
-
-  describe('Schema', function() {
-
-    it('should return the schema of a project', function() {
-      var p = new Project(testProject, apiClient);
-      expect( p ).to.respondTo('schema');
-      return expect( p.schema() ).to.eventually.be.deep.equal(
+      expect( p ).to.have.property('schema');
+      expect( p.schema ).to.be.deep.equal(
       {
         a: "Number",
         b: "Number",

--- a/test/ProjectCollection.spec.js
+++ b/test/ProjectCollection.spec.js
@@ -55,7 +55,7 @@ describe('Projects', function() {
 
     it('should find data schema for a project', function() {
       return expect( wordsmith.projects.find(testProjectSlug).then(function(project) {
-        return project.schema();
+        return project.schema;
       }) )
         .to.eventually.be.deep.equal(
         {

--- a/test/testConfig.json
+++ b/test/testConfig.json
@@ -7,6 +7,7 @@
   "testProject": {
     "name": "Test",
     "slug": "test",
+    "schema": { "a": "Number", "b": "Number", "c": "Number" },
     "templates": [
       {
         "name": "Test",


### PR DESCRIPTION
#### What does this PR do?

Updates the Node SDK to prepare the way for v1.1 of the Wordsmith API.  The existing version of this SDK should continue to function after the v1.1 API is released.  However, updating to this version should improve performance slightly as a separate API request to get the schema is no longer necessary.  We should release this update at the same time the v1.1 API is released to Wordsmith.

We can bump the version number of this package after the PR is accepted.
#### Impacted areas in application
- `Project`
#### Steps to test?
- Unit tests: `mocha`
  - By default all tests run against the production Wordsmith API.  All tests should pass.  You can also run tests against the v1.1 API locally with a few changes:
  - In the Wordsmith repo, pull the most recent development branch and start a server on port 3000 and be sure to set the binding.
    - `bundle exec rails s -b 127.0.0.1`
  - Change the host in `lib/config.js` to `host: 'localhost',`
  - Change the key in `test/testConfig.json` with your API key.
  - Change the following lines in `lib/API.js` to the following:
    - Line 3: `var https = require('http');`
    - Line 87: `port: 3000`
  - In Wordsmith, create a project named "test" with a template named "test".  The data should include 3 column titled "a", "b", and "c" which contain Number data.
- Manual tests:
  - Continue to use the same setup from local Wordsmith testing above (e.g. local server, changes in `lib/config.js` and `lib/API.js`).
  - Open a node console and load the sdk package.
    - From the package root in a terminal: `$ node`
    - `var wordsmith = require('./lib/wordsmith')(YOUR_API_KEY,'official-node-sdk-test');`
  - `wordsmith.projects.all().then(function(projects) { console.log(projects); }` and verify that projects load with templates and schema attributes.
  - `wordsmith.projects.find('test').then(function(p){ project = p; });`
  - Run `project.schema` and verify schema hash is returned.
  - Run `project.templates.all()` and verify template collection is returned.
##### What are the relevant outstanding Pull Requests?
- None
